### PR TITLE
Fix CCITT b1 selection so vertical modes cannot move backwards

### DIFF
--- a/scripts/test-native-ccitt.mjs
+++ b/scripts/test-native-ccitt.mjs
@@ -344,6 +344,18 @@ function testGroup4ModesAndEofb() {
     0x0f, 0xf0, 0x00
   ]);
 
+  // T.6 defines b1 as the first changing element on the reference line
+  // strictly to the right of a0, where a0 starts every row on the imaginary
+  // changing element positioned just before column 0. Here the reference row
+  // changes to black exactly at column 3 and the coding row reaches column 3
+  // in white, so b1 must skip that coincident element rather than return a0
+  // itself. Reference row: H + white(3) + black(1) + V(0), black span [3,4).
+  // Coding row: V_L(2), V_L(1), V_L(1), V(0), black spans [1,3) and [7,8).
+  const coincidentReferenceElement = decode(bits(
+    `001 1000 010 1 000010 010 010 1 ${eofb}`
+  ), { K: -1, Columns: 8, EndOfBlock: true, BlackIs1: true });
+  assertResult(coincidentReferenceElement, [0x10, 0x61], 8, 2, "end-of-block");
+
   assert.throws(
     () => decode(bits("1"), { K: -1, Columns: 8, EndOfBlock: true }),
     hasPdfError("invalid-object", /without an EOFB/)

--- a/src/pdf/nativeCcitt.ts
+++ b/src/pdf/nativeCcitt.ts
@@ -486,6 +486,10 @@ function decodeTwoDimensionalRow(
   const transitions: number[] = [];
   let position = 0;
   let black = false;
+  // T.4 4.2.1.3.1 starts every coding line on an imaginary changing element
+  // situated just before its first picture element. Only that first element
+  // allows b1 to sit on column 0; afterwards a0 is the last decoded position.
+  let atRowStart = true;
   while (position < columns) {
     budget.consume();
     const mode = decodeCode(reader, MODE_CODES, 7, "two-dimensional mode");
@@ -495,7 +499,9 @@ function decodeTwoDimensionalRow(
         details: { reason: "ccitt-extension-mode", bitOffset: reader.position }
       });
     }
-    const referencePoint = findReferenceTransition(reference, position, black, columns);
+    const a0 = atRowStart ? -1 : position;
+    atRowStart = false;
+    const referencePoint = findReferenceTransition(reference, a0, black, columns);
     if (mode.kind === "pass") {
       if (referencePoint.b2 <= position) {
         throw malformed(reader, "CCITT pass mode does not advance the row.", "ccitt-pass-no-progress");
@@ -600,7 +606,7 @@ function decodeCode<T>(
 
 function findReferenceTransition(
   transitions: readonly number[],
-  position: number,
+  a0: number,
   black: boolean,
   columns: number
 ): { readonly b1: number; readonly b2: number } {
@@ -608,7 +614,10 @@ function findReferenceTransition(
   let high = transitions.length;
   while (low < high) {
     const middle = (low + high) >>> 1;
-    if (transitions[middle] < position) low = middle + 1;
+    // T.4 4.2.1.3.2 places b1 strictly to the right of a0. A reference
+    // element that coincides with a0 belongs to the run already coded, so
+    // skipping it is what keeps a vertical mode from moving backwards.
+    if (transitions[middle] <= a0) low = middle + 1;
     else high = middle;
   }
   // Even transition indexes enter black; odd indexes enter white. b1 enters


### PR DESCRIPTION
## What this fixes

The first of the four failures reported in #2: `CCITT vertical mode places a changing element outside the row.`

`decodeTwoDimensionalRow` asks `findReferenceTransition` for the first changing element **at or after** a0. T.4 4.2.1.3.2 defines b1 as the first changing element on the reference line **strictly to the right of** a0 and of opposite colour. When the reference row changes colour exactly at a0, b1 comes back as a0 itself, and any V_L(n) then places a1 before a0 — which the decoder refuses, correctly.

So the throw is the symptom, not the defect: the stream was conformant, b1 was not.

The search cannot simply become strict, though. T.4 4.2.1.3.1 starts every coding line on an imaginary changing element situated just before column 0, so a0 is -1 until the row's first mode is decoded. Without modelling that, a reference element on column 0 would now be skipped instead. The patch does both.

## Evidence

Measured on the one-page PDF attached to #2 (957 columns, 264 rows, `K -1`, `ImageMask`):

|                        | before          | after       |
| ---------------------- | --------------- | ----------- |
| rows decoded           | fails on row 20 | 264 / 264   |
| encoded bytes consumed | —               | 4819 / 4819 |
| terminated by          | —               | EOFB        |
| damaged rows           | —               | 0           |

The failure before the fix: `a0 = 168`, `b1 = 168`, `V_L(1)` → `a1 = 167`. The reference row's changing elements are `[168, 169, 170, ...]`; with b1 taken strictly to the right of a0, b1 is 170 and a1 is 169, which advances.

Consuming exactly the whole stream and landing on its EOFB is what says the stream was conformant rather than merely tolerable — and the decoded image is clean, with no row-level artefacts.

`node PDFtoHEP.js` on that PDF now completes in 2 s.

## Test

New case in `testGroup4ModesAndEofb`, placed right after the "all six nonzero vertical modes" block — whose comment already states that it keeps every b1 strictly ahead of a0. The situation was therefore avoided by the fixtures rather than covered by them.

Eight columns, same signature as the real file (`a0 = 3`, `b1 = 3`, `V_L(1)`). It fails on `main` with the exact production error and passes with the patch.

## Checks

- `npm run test:file` on `test-native-ccitt.mjs`, `test-native-ccitt-images.mjs`, `test-pdf-session-ccitt-images.mjs` — all pass
- `npm test` — `tsc --noEmit` clean, 36 / 37 fast files pass
- `npm run test:integration` — 41 / 41
- `npm run test:unit` — 66 / 68

The two failing files under `fast` / `unit` (`test-text-lod-core.mjs`, `test-room-segment-extractor.mjs`) also fail on `main` without this change. They are Windows-only: a POSIX-style path reaches Node as `/C:/dev/...` and resolves to `C:\C:\dev\...`. Unrelated to this patch — happy to open a separate issue if that is useful to you.

## Scope

Only the CCITT item of #2. The `/Square` annotation appearance, ICCBased and CID font failures are untouched; the first of those is a missing feature rather than a defect, and the policy question it raises is yours to settle.

Refs #2
