### PR TITLE
Trim fixed-width NUL padding in /CIDSystemInfo strings

### DIFF
--- a/scripts/test-native-font-cmap-semantics.mjs
+++ b/scripts/test-native-font-cmap-semantics.mjs
@@ -241,6 +241,25 @@ async function testCidUnicodeFallbackAndRos() {
   ]), identityResolver);
   assert.equal(explicitOverride.decode(Uint8Array.of(0x81, 0x40)).unicode, "Z");
 
+  // Some producers write /Registry and /Ordering as fixed-width strings and
+  // pad them with trailing NULs. The padding is not part of the collection
+  // name, so it has to be trimmed rather than rejected, and it must not be
+  // carried into the name either: a padded Japan1 font resolves the Japan1
+  // collection exactly like the unpadded one above.
+  const paddedSystemInfo = await parseNativePdfFont(
+    compositeFont(name("Identity-H"), new Map([
+      ["Subtype", name("CIDFontType2")],
+      ["CIDSystemInfo", new Map([
+        ["Registry", nulPaddedPdfString("Adobe")],
+        ["Ordering", nulPaddedPdfString("Japan1")],
+        ["Supplement", 7]
+      ])]
+    ])),
+    identityResolver
+  );
+  assert.equal(paddedSystemInfo.decode(Uint8Array.of(0x02, 0x79)).unicode, "\u3000");
+  assert.equal(paddedSystemInfo.decode(Uint8Array.of(0x20, 0x67)).unicode, "XIII");
+
   const gbDiagnostics = [];
   const gb = await parseNativePdfFont(
     compositeFont(name("Identity-H"), cidFont("GB1", 6)),
@@ -298,6 +317,24 @@ async function testCidUnicodeFallbackAndRos() {
     identityResolver
   );
   assert.equal(embeddedJapan.decode(Uint8Array.of(0x41)).unicode, "\u3000");
+
+  // The embedded-CMap validator duplicates the dictionary rule above and has
+  // to trim the same fixed-width NUL padding. <4a6170616e310000> is Japan1
+  // padded to eight bytes, <41646f626500> is Adobe padded to six.
+  const paddedEmbeddedEncoding = stream(`
+    /CIDSystemInfo 3 dict dup begin
+      /Registry <41646f626500> def
+      /Ordering <4a6170616e310000> def
+      /Supplement 7 def
+    end def
+    1 begincodespacerange <00> <ff> endcodespacerange
+    1 begincidchar <41> 633 endcidchar
+  `);
+  const paddedEmbedded = await parseNativePdfFont(
+    compositeFont(paddedEmbeddedEncoding, cidFont("Japan1", 7)),
+    identityResolver
+  );
+  assert.equal(paddedEmbedded.decode(Uint8Array.of(0x41)).unicode, "\u3000");
   await assert.rejects(
     parseNativePdfFont(
       compositeFont(embeddedJapanEncoding, cidFont("GB1", 6)),
@@ -715,6 +752,10 @@ function cidSystemInfo(ordering, supplement) {
     ["Ordering", pdfString(ordering)],
     ["Supplement", supplement]
   ]);
+}
+
+function nulPaddedPdfString(value) {
+  return { kind: "string", bytes: Uint8Array.of(...encoder.encode(value), 0, 0), hex: false };
 }
 
 function pdfString(value) {

--- a/src/pdf/nativeFont.ts
+++ b/src/pdf/nativeFont.ts
@@ -846,8 +846,21 @@ async function readCidSystemInfoString(
       "font-cid-system-info-string"
     );
   }
+  // Producers routinely emit these as fixed-width strings padded with
+  // trailing NULs. The padding carries no part of the collection name, so it
+  // is trimmed before the character check; every other byte outside
+  // printable ASCII remains an error.
+  let length = value.bytes.length;
+  while (length > 0 && value.bytes[length - 1] === 0) length -= 1;
+  if (length < 1) {
+    throw cidSystemInfoError(
+      `${label} /${key} must contain at least one non-NUL byte.`,
+      "font-cid-system-info-string"
+    );
+  }
   let result = "";
-  for (const byte of value.bytes) {
+  for (let index = 0; index < length; index += 1) {
+    const byte = value.bytes[index];
     if (byte < 0x20 || byte > 0x7e) {
       throw cidSystemInfoError(
         `${label} /${key} must contain printable ASCII.`,
@@ -2027,8 +2040,20 @@ function requireCMapSystemInfoString(
   ) {
     throw unsupportedFont(`CMap /CIDSystemInfo has no valid /${key} string.`);
   }
+  // Mirrors readCidSystemInfoString: fixed-width padding with trailing NULs
+  // is not part of the collection name, so it is trimmed before the
+  // character check; every other non-printable byte remains an error.
+  const bytes = values[0].value;
+  let length = bytes.length;
+  while (length > 0 && bytes[length - 1] === 0) length -= 1;
+  if (length < 1) {
+    throw unsupportedFont(
+      `CMap /CIDSystemInfo /${key} must contain at least one non-NUL byte.`
+    );
+  }
   let result = "";
-  for (const byte of values[0].value) {
+  for (let index = 0; index < length; index += 1) {
+    const byte = bytes[index];
     if (byte < 0x20 || byte > 0x7e) {
       throw unsupportedFont(`CMap /CIDSystemInfo /${key} must contain printable ASCII.`);
     }


### PR DESCRIPTION
## What this fixes

The CID font item of #2: `CID font /CIDSystemInfo /Ordering must contain printable ASCII.`

Probed on a real-world MEP drawing that opens on v0.1.23, the offending `/Ordering` is:

```
49 64 65 6e 74 69 74 79 00 00   ->   "Identity\0\0"
```

That is `Identity` — the most ordinary collection there is — written as a fixed-width string and padded with two NULs. The padding is the only thing the validator objects to.

`readCidSystemInfoString` now trims trailing NULs before the character check. Everything else stays strict: any other byte outside printable ASCII is still an error, and a string made only of NULs is refused with its own message instead of silently becoming empty.

Trimming rather than merely tolerating is the point. The value is compared against collection names, so a kept `"Japan1\0\0"` would resolve no collection at all and quietly fall through to the unavailable-fallback path — a wrong result instead of a loud one.

`requireCMapSystemInfoString` duplicates the same rule for embedded CMaps, so it gets the same treatment. Leaving them apart would make the two validators disagree about the same field of the same standard, and a producer that pads one can pad the other.

## Tests

Two cases in `testCidUnicodeFallbackAndRos`, one per validator: a CID font dictionary whose ROS strings carry NUL padding, and an embedded CMap declaring `/Registry <41646f626500>` and `/Ordering <4a6170616e310000>`.

Both use a padded **Japan1** rather than Identity on purpose. If the padding were kept instead of trimmed, the collection would not resolve and the assertions on decoded Unicode would fail — so the tests tell "trim" apart from "merely tolerate", which asserting on Identity could not.

Both fail on `main` with the production error and pass with the patch.

## Checks

- `npm run test:file -- scripts/test-native-font-cmap-semantics.mjs` — passes
- `npm test` — `tsc --noEmit` clean, 36 / 37 fast files pass
- `npm run test:integration` — 41 / 41
- `npm run test:unit` — 66 / 68

The two failing files (`test-text-lod-core.mjs`, `test-room-segment-extractor.mjs`) also fail on `main` without this change. They are Windows-only: a POSIX-style path reaches Node as `/C:/dev/...` and resolves to `C:\C:\dev\...`. Unrelated to this patch.

No existing test asserted the old rejection, so nothing here loosens a documented expectation.

## Scope

Only the CID font item of #2, and independent of #4 (CCITT). The `/Square` annotation and ICCBased items are untouched — the first of those is a missing feature rather than a defect, and the policy question it raises is yours to settle.

Refs #2
