### PR TITLE
Synthesize /Square annotation appearances

### DIFF
--- a/scripts/test-native-appearance-synthesis.mjs
+++ b/scripts/test-native-appearance-synthesis.mjs
@@ -161,6 +161,7 @@ try {
     diagnostic.code === "annotation.appearance-synthesized"
   ));
   await testLinkAppearanceSynthesis();
+  await testSquareAppearanceSynthesis();
 } finally {
   await document.close();
   hooks.deregister();
@@ -386,6 +387,91 @@ function fixture() {
       { number: 65, body: "<< /FT /Ch /T (List) /Ff 2097152 /Opt [(One) (Two) (Three) (Four)] /V [(Two) (Four)] /I [1 3] /TI 1 /DA (/Helv 9 Tf 0 g) /Kids [24 0 R] >>" },
       { number: 66, body: "<< /FT /Tx /T (Comb) /Ff 16777216 /MaxLen 4 /V (123) /Q 2 /Kids [25 0 R] >>" },
       { number: 99, body: tinyPdfStream("/Type /XObject /Subtype /Form /BBox [0 0 1 1]", "") }
+    ]
+  });
+}
+
+async function testSquareAppearanceSynthesis() {
+  const squareDocument = await openNativePdfDocument({
+    kind: "bytes",
+    bytes: squareFixture()
+  });
+  try {
+    const registry = new NativePdfFormAppearanceRegistry(squareDocument);
+    const synthesizer = new NativePdfAppearanceSynthesizer(squareDocument);
+    const annotations = await registry.listPageAnnotations(0);
+    assert.equal(annotations.length, 6);
+    const resolve = (annotation) =>
+      resolveNativePdfAnnotationAppearanceWithSynthesis(registry, synthesizer, annotation);
+
+    // A zero-width border with no interior colour paints nothing at all. Such
+    // an annotation must not fail the page: real drawings carry these as pure
+    // metadata markers.
+    assert.equal(await resolve(annotations[0]), null);
+
+    // /C is absent, so the border takes the interoperable black default, and
+    // the stroked rectangle is inset by half the border width.
+    const defaulted = await resolve(annotations[1]);
+    assert(defaulted?.synthesized);
+    const defaultedContent = decoder.decode(defaulted.decodedContent);
+    assert.match(defaultedContent, /0 G/);
+    assert.match(defaultedContent, /2 w/);
+    assert.match(defaultedContent, /1 1 38 18 re S/);
+
+    // An interior colour paints even when the border width is zero.
+    const filledOnly = await resolve(annotations[2]);
+    assert(filledOnly?.synthesized);
+    const filledOnlyContent = decoder.decode(filledOnly.decodedContent);
+    assert.match(filledOnlyContent, /1 0 0 rg/);
+    assert.match(filledOnlyContent, /0 0 40 20 re f/);
+    assert.doesNotMatch(filledOnlyContent, / S/);
+
+    // Border and interior together fill and stroke the same inset rectangle.
+    const both = await resolve(annotations[3]);
+    assert(both?.synthesized);
+    const bothContent = decoder.decode(both.decodedContent);
+    assert.match(bothContent, /1 1 0 rg/);
+    assert.match(bothContent, /0 0 1 RG/);
+    assert.match(bothContent, /1 1 38 18 re B/);
+
+    // An empty /C is transparent, so the interior is painted on its own. The
+    // declared border width still positions the path: colour decides what is
+    // painted, width decides where the path runs, so the fill stays inset.
+    const transparentBorder = await resolve(annotations[4]);
+    assert(transparentBorder?.synthesized);
+    const transparentContent = decoder.decode(transparentBorder.decodedContent);
+    assert.match(transparentContent, /0 1 0 rg/);
+    assert.match(transparentContent, /1 1 38 18 re f/);
+    assert.doesNotMatch(transparentContent, / re B/);
+
+    // A fully transparent annotation contributes no display command.
+    assert.equal(await resolve(annotations[5]), null);
+  } finally {
+    await squareDocument.close();
+  }
+}
+
+function squareFixture() {
+  return writeTinyPdf({
+    objects: [
+      { number: 1, body: "<< /Type /Catalog /Pages 2 0 R >>" },
+      { number: 2, body: "<< /Type /Pages /Count 1 /Kids [3 0 R] >>" },
+      {
+        number: 3,
+        body: [
+          "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 240 100] /Resources << >>",
+          "/Annots [10 0 R 11 0 R 12 0 R 13 0 R 14 0 R 15 0 R] >>"
+        ].join(" ")
+      },
+      { number: 10, body: "<< /Type /Annot /Subtype /Square /Rect [0 0 40 20] /Border [0 0 0] >>" },
+      { number: 11, body: "<< /Type /Annot /Subtype /Square /Rect [45 0 85 20] /Border [0 0 2] >>" },
+      { number: 12, body: "<< /Type /Annot /Subtype /Square /Rect [90 0 130 20] /Border [0 0 0] /IC [1 0 0] >>" },
+      {
+        number: 13,
+        body: "<< /Type /Annot /Subtype /Square /Rect [135 0 175 20] /Border [0 0 2] /C [0 0 1] /IC [1 1 0] >>"
+      },
+      { number: 14, body: "<< /Type /Annot /Subtype /Square /Rect [180 0 220 20] /Border [0 0 2] /C [] /IC [0 1 0] >>" },
+      { number: 15, body: "<< /Type /Annot /Subtype /Square /Rect [0 30 40 50] /Border [0 0 2] /C [0 0 1] /CA 0 >>" }
     ]
   });
 }

--- a/src/pdf/nativeAppearanceSynthesis.ts
+++ b/src/pdf/nativeAppearanceSynthesis.ts
@@ -208,8 +208,12 @@ export class NativePdfAppearanceSynthesizer {
       await this.requireMissingNormalAppearance(annotation, signal);
       return await this.synthesizeLinkBorder(annotation, optionalContentIndex, signal);
     }
+    if (annotation.subtype === "Square") {
+      await this.requireMissingNormalAppearance(annotation, signal);
+      return await this.synthesizeSquare(annotation, optionalContentIndex, signal);
+    }
     if (annotation.subtype !== "Widget" || !annotation.widget) {
-      throw synthesisError(annotation, "Only AcroForm Widgets and Link borders have synthesizable appearances.", {
+      throw synthesisError(annotation, "Only AcroForm Widgets, Link borders, and Squares have synthesizable appearances.", {
         reason: "appearance-synthesis-unsupported-subtype",
         subtype: annotation.subtype
       });
@@ -373,7 +377,7 @@ export class NativePdfAppearanceSynthesizer {
     optionalContentIndex: number,
     signal?: AbortSignal
   ): Promise<NativePdfSynthesizedAppearance | null> {
-    const border = await this.readLinkBorderStyle(annotation, signal);
+    const border = await this.readAnnotationBorderStyle(annotation, "Link", signal);
     // A zero-width border is explicitly non-painting. It is not an unsupported
     // visible annotation and therefore needs neither a display command nor a
     // synthetic empty Form.
@@ -404,7 +408,7 @@ export class NativePdfAppearanceSynthesizer {
       });
     }
 
-    const geometry = this.readLinkGeometry(annotation);
+    const geometry = this.readAnnotationGeometry(annotation, "Link");
     if (!geometry) return null;
     if (border.width > Math.min(geometry.width, geometry.height)) {
       throw new PdfError("invalid-object", "Link border width exceeds its appearance bounds.", {
@@ -457,14 +461,94 @@ export class NativePdfAppearanceSynthesizer {
     );
   }
 
-  private readLinkGeometry(
-    annotation: NativePdfAnnotationAppearance
+  /**
+   * ISO 32000-1 12.5.6.8. The square is drawn inside /Rect, on a path inset by
+   * half the border width, stroked with /C and filled with /IC. A square with
+   * neither a painting border nor an interior colour paints nothing at all:
+   * like a zero-width Link border it is not an unsupported visible annotation,
+   * and real drawings carry such squares as pure metadata markers.
+   */
+  private async synthesizeSquare(
+    annotation: NativePdfAnnotationAppearance,
+    optionalContentIndex: number,
+    signal?: AbortSignal
+  ): Promise<NativePdfSynthesizedAppearance | null> {
+    const border = await this.readAnnotationBorderStyle(annotation, "Square", signal);
+    const strokeColor = border.width > 0
+      ? await this.readAnnotationColor(annotation, "C", DEFAULT_COLOR, "Square annotation", signal)
+      : null;
+    // /IC has no default: an absent interior colour leaves the square unfilled,
+    // unlike /C, which falls back to black for a border that does paint.
+    const fillColor = await this.readAnnotationColor(annotation, "IC", null, "Square annotation", signal);
+    if (!strokeColor && !fillColor) return null;
+
+    const opacity = await optionalFiniteNumber(
+      this.document,
+      annotation.dictionary,
+      "CA",
+      1,
+      signal,
+      "Square annotation"
+    );
+    if (opacity < 0 || opacity > 1) {
+      throw new PdfError("invalid-object", "Square annotation /CA must be from 0 through 1.", {
+        pageIndex: annotation.pageIndex,
+        details: { annotationIndex: annotation.annotationIndex, feature: "appearance-synthesis" }
+      });
+    }
+    if (opacity === 0) return null;
+    if (opacity !== 1) {
+      throw synthesisError(annotation, "A translucent Square annotation is not yet synthesizable.", {
+        reason: "appearance-square-opacity-unsupported",
+        opacity
+      });
+    }
+
+    const geometry = this.readAnnotationGeometry(annotation, "Square");
+    if (!geometry) return null;
+    if (border.width > Math.min(geometry.width, geometry.height)) {
+      throw new PdfError("invalid-object", "Square border width exceeds its appearance bounds.", {
+        pageIndex: annotation.pageIndex,
+        details: { annotationIndex: annotation.annotationIndex, feature: "appearance-synthesis" }
+      });
+    }
+
+    // The border straddles the path, so the path is inset by half of it. A
+    // transparent /C still reserves that width: the colour decides what is
+    // painted, the declared width decides where the path runs.
+    const inset = border.width / 2;
+    const lines = ["q"];
+    if (fillColor) lines.push(fillColorOperator(fillColor));
+    if (strokeColor) {
+      lines.push(strokeColorOperator(strokeColor), `${pdfNumber(border.width)} w`);
+      if (border.style === "dashed") {
+        lines.push(`[${border.dash.map(pdfNumber).join(" ")}] 0 d`);
+      }
+    }
+    lines.push(
+      `${pdfNumber(inset)} ${pdfNumber(inset)} ${pdfNumber(geometry.width - border.width)} ` +
+      `${pdfNumber(geometry.height - border.width)} re ${fillColor ? (strokeColor ? "B" : "f") : "S"}`,
+      "Q"
+    );
+    return this.finishSynthesis(
+      annotation,
+      geometry,
+      encodeContent(lines),
+      new Map<string, PdfValue>(),
+      "empty",
+      optionalContentIndex
+    );
+  }
+
+  private readAnnotationGeometry(
+    annotation: NativePdfAnnotationAppearance,
+    label: string
   ): LogicalAppearanceGeometry | null {
     const width = annotation.rectangle[2] - annotation.rectangle[0];
     const height = annotation.rectangle[3] - annotation.rectangle[1];
     if (width === 0 || height === 0) return null;
     if (width >= 1e20 || height >= 1e20) {
-      throw new PdfError("resource-limit", "A Link /Rect exceeds the synthesized appearance coordinate limit.", {
+      throw new PdfError("resource-limit", `A ${label} /Rect exceeds the synthesized appearance coordinate limit.`, {
         pageIndex: annotation.pageIndex,
         details: {
           annotationIndex: annotation.annotationIndex,
@@ -922,14 +1006,24 @@ export class NativePdfAppearanceSynthesizer {
     annotation: NativePdfAnnotationAppearance,
     signal?: AbortSignal
   ): Promise<AppearanceColor | null> {
-    const raw = await this.document.resolveValue(annotation.dictionary.get("C"), signal);
     // Annotation colour has no explicit ISO default. Black is the interoperable
     // default used by existing processors when a Link has a painting border.
-    if (raw === undefined || raw === null) return DEFAULT_COLOR;
+    return await this.readAnnotationColor(annotation, "C", DEFAULT_COLOR, "Link annotation", signal);
+  }
+
+  private async readAnnotationColor(
+    annotation: NativePdfAnnotationAppearance,
+    key: "C" | "IC",
+    missing: AppearanceColor | null,
+    label: string,
+    signal?: AbortSignal
+  ): Promise<AppearanceColor | null> {
+    const raw = await this.document.resolveValue(annotation.dictionary.get(key), signal);
+    if (raw === undefined || raw === null) return missing;
     if (!Array.isArray(raw) || ![0, 1, 3, 4].includes(raw.length)) {
       throw new PdfError(
         "invalid-object",
-        "Link annotation /C is not a transparent, DeviceGray, RGB, or CMYK color array.",
+        `${label} /${key} is not a transparent, DeviceGray, RGB, or CMYK color array.`,
         {
           pageIndex: annotation.pageIndex,
           details: { annotationIndex: annotation.annotationIndex, feature: "appearance-synthesis" }
@@ -944,7 +1038,7 @@ export class NativePdfAppearanceSynthesizer {
         typeof component !== "number" || !Number.isFinite(component) ||
         component < 0 || component > 1
       ) {
-        throw new PdfError("invalid-object", "Link annotation /C contains an invalid component.", {
+        throw new PdfError("invalid-object", `${label} /${key} contains an invalid component.`, {
           pageIndex: annotation.pageIndex,
           details: { annotationIndex: annotation.annotationIndex, feature: "appearance-synthesis" }
         });
@@ -954,8 +1048,9 @@ export class NativePdfAppearanceSynthesizer {
     return Object.freeze({ components: Object.freeze(components) });
   }
 
-  private async readLinkBorderStyle(
+  private async readAnnotationBorderStyle(
     annotation: NativePdfAnnotationAppearance,
+    label: string,
     signal?: AbortSignal
   ): Promise<LinkBorderStyle> {
     const rawStyle = annotation.dictionary.get("BS");
@@ -963,10 +1058,10 @@ export class NativePdfAppearanceSynthesizer {
       const dictionary = await this.document.resolveDictionary(rawStyle, signal);
       const type = await this.document.resolveValue(dictionary.get("Type"), signal);
       if (type !== undefined && type !== null && !isPdfName(type, "Border")) {
-        throw invalidBorder(annotation, "Link /BS has an invalid /Type.");
+        throw invalidBorder(annotation, `${label} /BS has an invalid /Type.`);
       }
-      const width = await optionalFiniteNumber(this.document, dictionary, "W", 1, signal, "Link /BS");
-      if (width < 0) throw invalidBorder(annotation, "Link /BS /W cannot be negative.");
+      const width = await optionalFiniteNumber(this.document, dictionary, "W", 1, signal, `${label} /BS`);
+      if (width < 0) throw invalidBorder(annotation, `${label} /BS /W cannot be negative.`);
       if (width === 0) {
         return Object.freeze({
           width,
@@ -978,17 +1073,17 @@ export class NativePdfAppearanceSynthesizer {
       }
       const rawName = await this.document.resolveValue(dictionary.get("S"), signal);
       if (rawName !== undefined && rawName !== null && !isPdfName(rawName)) {
-        throw invalidBorder(annotation, "Link /BS /S is not a name.");
+        throw invalidBorder(annotation, `${label} /BS /S is not a name.`);
       }
       const name = rawName?.value ?? "S";
       if (name === "B" || name === "I") {
-        throw synthesisError(annotation, "Beveled and inset Link borders are not safely synthesizable.", {
+        throw synthesisError(annotation, `Beveled and inset ${label} borders are not safely synthesizable.`, {
           reason: "appearance-border-style-unsupported",
           borderStyle: name
         });
       }
       if (name !== "S" && name !== "D" && name !== "U") {
-        throw synthesisError(annotation, `Link border style /${name} is unsupported.`, {
+        throw synthesisError(annotation, `${label} border style /${name} is unsupported.`, {
           reason: "appearance-border-style-unsupported",
           borderStyle: name
         });
@@ -1016,7 +1111,7 @@ export class NativePdfAppearanceSynthesizer {
       });
     }
     if (!Array.isArray(rawBorder) || (rawBorder.length !== 3 && rawBorder.length !== 4)) {
-      throw invalidBorder(annotation, "Link /Border is not a three- or four-element array.");
+      throw invalidBorder(annotation, `${label} /Border is not a three- or four-element array.`);
     }
     const values: PdfValue[] = [];
     for (let index = 0; index < 3; index += 1) {
@@ -1024,16 +1119,16 @@ export class NativePdfAppearanceSynthesizer {
     }
     for (let index = 0; index < 3; index += 1) {
       if (typeof values[index] !== "number" || !Number.isFinite(values[index] as number)) {
-        throw invalidBorder(annotation, "Link /Border contains an invalid number.");
+        throw invalidBorder(annotation, `${label} /Border contains an invalid number.`);
       }
     }
     const horizontalRadius = values[0] as number;
     const verticalRadius = values[1] as number;
     const width = values[2] as number;
     if (horizontalRadius < 0 || verticalRadius < 0) {
-      throw invalidBorder(annotation, "Link /Border corner radii cannot be negative.");
+      throw invalidBorder(annotation, `${label} /Border corner radii cannot be negative.`);
     }
-    if (width < 0) throw invalidBorder(annotation, "Link /Border width cannot be negative.");
+    if (width < 0) throw invalidBorder(annotation, `${label} /Border width cannot be negative.`);
     if (width === 0) {
       return Object.freeze({
         width,
@@ -1164,7 +1259,8 @@ export async function resolveNativePdfAnnotationAppearanceWithSynthesis(
       !(error instanceof PdfError) ||
       error.code !== "unsupported-content" ||
       error.details?.reason !== "appearance-synthesis-not-implemented" ||
-      (annotation.subtype !== "Link" && (annotation.subtype !== "Widget" || !annotation.widget))
+      (annotation.subtype !== "Link" && annotation.subtype !== "Square" &&
+        (annotation.subtype !== "Widget" || !annotation.widget))
     ) {
       throw error;
     }


### PR DESCRIPTION
## What this fixes

The `/Square` item of #2: `Visible /Square annotation 0 has no usable normal appearance; native synthesis is not implemented.`

The annotation that triggers it, probed from a real drawing, is:

```
/Subtype /Square  /Rect [938 2102 925 2158]  /Border [0 0 0]  /F 64
no /AP, no /C, no /IC, no /CA
```

A zero-width border with no interior colour. It paints **nothing** — and it takes the whole page down with it. That is what makes this worth fixing rather than tolerating: the correct appearance for this annotation is the empty one.

`nativeAppearanceSynthesis.ts` already had the mechanism and the precedent. `/Link` returns `null` for a zero-width border, documented there as *"explicitly non-painting… not an unsupported visible annotation"*. `/Square` now follows the same rule, so the registry's policy — hidden annotations return null, visible unsupported ones fail — is untouched.

## What the synthesis does

ISO 32000-1 12.5.6.8, matching what existing processors draw:

- path = `/Rect` inset by half the border width (the border straddles the path)
- `/C` strokes it, falling back to black when absent, exactly as `/Link` already does
- `/IC` fills it; unlike `/C` it has no default, so an absent `/IC` simply leaves the square unfilled
- operator `B`, `f` or `S` depending on which of the two colours paints
- `/CA` 0 returns `null`; a translucent square raises the same typed "not yet synthesizable" error that a translucent Link border does
- neither a painting border nor an interior colour → `null`

One deliberate call worth flagging: an **empty** `/C` is transparent (as the existing `/Link` tests already assert), but the declared border width still positions the path. Colour decides what is painted, width decides where the path runs — so a transparent border with an interior colour fills the *inset* rectangle, not the full `/Rect`. The test states this explicitly.

Three helpers became subtype-neutral so `/Square` could reuse them rather than duplicate their validation: `readAnnotationColor(key, missing, label)`, `readAnnotationBorderStyle(annotation, label, signal)` and `readAnnotationGeometry(annotation, label)`. `/Link` keeps its exact diagnostics through the label argument.

## Tests

`testSquareAppearanceSynthesis` covers six squares in one fixture page: the non-painting one from the real file, a `/C`-less black border, an interior colour with a zero-width border, border plus interior, a transparent `/C` with an interior, and `/CA 0`. Each asserts the emitted content stream, so the inset arithmetic and the choice of `B`/`f`/`S` are pinned, not just the absence of a throw.

All six fail on `main` with the production error.

## Checks

- `npm run test:file -- scripts/test-native-appearance-synthesis.mjs` — passes, `/Link` and `/Widget` cases included
- `npm test` — `tsc --noEmit` clean, 36 / 37 fast files pass
- `npm run test:integration` — 41 / 41
- `npm run test:unit` — 66 / 68
- the real drawing now converts through `node PDFtoHEP.js`

The two failing files (`test-text-lod-core.mjs`, `test-room-segment-extractor.mjs`) also fail on `main` without this change; they are Windows-only path failures (`/C:/dev/...` resolving to `C:\C:\dev\...`), unrelated here.

## Scope

`/Square` only. `/Circle` is its twin in 12.5.6.8 and would reuse all of this plus the `ellipsePath` helper already in the file — happy to add it here or in a follow-up, whichever you prefer. Independent of #4 and #5.

Refs #2
