### PR TITLE
Accept the EOL marker some producers count in a stream /Length

### DIFF
--- a/scripts/test-native-filter-semantics.mjs
+++ b/scripts/test-native-filter-semantics.mjs
@@ -135,6 +135,29 @@ async function testFlate() {
     hasPdfError("invalid-object", /empty/)
   );
 
+  // PDF 32000-1 7.3.8.1 puts an EOL marker after the stream data and excludes
+  // it from /Length. Producers that count it anyway leave a stray CR, LF, or
+  // CRLF after an otherwise complete zlib stream. The marker is not data, and
+  // the payload it follows decodes to exactly the same bytes.
+  for (const marker of [[0x0a], [0x0d], [0x0d, 0x0a]]) {
+    assert.deepEqual(
+      await decodeOne(concat(zlib, Uint8Array.from(marker)), "FlateDecode"),
+      decoded,
+      `zlib stream followed by a ${marker.length}-byte EOL marker`
+    );
+  }
+
+  // Only that marker is specified to sit there. Other trailing bytes, other
+  // whitespace, and more than one marker stay errors.
+  for (const junk of [[0x20], [0x09], [0x0a, 0x0a], [0x0a, 0x0d], [0x0d, 0x0a, 0x0a]]) {
+    await assert.rejects(
+      decodeOne(concat(zlib, Uint8Array.from(junk)), "FlateDecode"),
+      hasPdfError("invalid-object", /FlateDecode/),
+      `zlib stream followed by ${JSON.stringify(junk)}`
+    );
+  }
+
+
   // 0x7820 has a valid FCHECK and advertises FDICT. PDF Flate streams cannot
   // supply the external dictionary, so this is a deterministic typed failure.
   await assert.rejects(

--- a/src/pdf/nativeFilters.ts
+++ b/src/pdf/nativeFilters.ts
@@ -252,6 +252,46 @@ async function* decodeFlateChunks(
   }
 }
 
+/**
+ * True when `inputs` end with a single EOL marker whose removal yields a
+ * stream that decodes to exactly `producedLength` bytes. Nothing else is
+ * trimmed: NUL, spaces, tabs and repeated markers stay decode failures.
+ */
+async function decodesIdenticallyWithoutEolMarker(
+  inputs: readonly Uint8Array[],
+  format: "deflate" | "deflate-raw",
+  limit: number,
+  signal: AbortSignal | undefined,
+  producedLength: number
+): Promise<boolean> {
+  const trimmed = withoutTrailingEolMarker(inputs);
+  if (!trimmed) return false;
+  const state: PlatformInflateState = { length: 0 };
+  try {
+    for await (const chunk of inflatePlatformChunks(trimmed, format, limit, signal, state, false)) {
+      void chunk;
+    }
+  } catch {
+    return false;
+  }
+  return state.length === producedLength;
+}
+
+/** The trailing CR, LF, or CRLF removed, or null when there is no marker. */
+function withoutTrailingEolMarker(
+  inputs: readonly Uint8Array[]
+): readonly Uint8Array[] | null {
+  let lastIndex = inputs.length - 1;
+  while (lastIndex >= 0 && inputs[lastIndex].length === 0) lastIndex -= 1;
+  if (lastIndex < 0) return null;
+  const last = inputs[lastIndex];
+  let end = last.length;
+  if (last[end - 1] === 0x0a) end -= 1;
+  if (end > 0 && last[end - 1] === 0x0d) end -= 1;
+  if (end === last.length || end === 0) return null;
+  return [...inputs.slice(0, lastIndex), last.subarray(0, end)];
+}
+
 function classifyFlateWrapper(input: Uint8Array): "zlib" | "raw" {
   if (input.length === 0) throw new PdfError("invalid-object", "FlateDecode stream is empty.");
   const cmf = input[0];
@@ -303,7 +343,8 @@ async function* inflatePlatformChunks(
   format: "deflate" | "deflate-raw",
   limit: number,
   signal: AbortSignal | undefined,
-  state: PlatformInflateState
+  state: PlatformInflateState,
+  recoverEolMarker = true
 ): AsyncIterable<Uint8Array> {
   if (typeof DecompressionStream !== "function") {
     throw new PdfError("unsupported-filter", "FlateDecode requires DecompressionStream support.");
@@ -348,6 +389,19 @@ async function* inflatePlatformChunks(
     await reader.cancel().catch(() => undefined);
     if (cause instanceof PdfError) throw cause;
     if (signal?.aborted) throwIfAborted(signal);
+    // PDF 32000-1 7.3.8.1 places an EOL marker after the stream data and keeps
+    // it out of /Length. Producers that count it leave a stray CR, LF, or CRLF
+    // that platform decoders reject as trailing junk, discarding a payload that
+    // was already complete. Accept that marker, but only after re-decoding
+    // without it proves the same byte count: a truncated stream cannot be
+    // rescued this way, and any other trailing byte remains an error.
+    if (
+      recoverEolMarker &&
+      await decodesIdenticallyWithoutEolMarker(inputs, format, limit, signal, state.length)
+    ) {
+      completed = true;
+      return;
+    }
     throw new PdfError("invalid-object", "Malformed FlateDecode stream.", { cause });
   } finally {
     if (!completed) {


### PR DESCRIPTION
## What this fixes

Two unrelated real-world PDFs failed with `Malformed FlateDecode stream.` Probed at the failure point, the underlying cause is the same in both:

```
Trailing junk found after the end of the compressed stream
```

| | stream A | stream B |
| --- | --- | --- |
| complete zlib stream | 7760 bytes | 1835 bytes |
| already decoded | 8321 bytes | 4075 bytes |
| trailing bytes | **1** (`0x0d`) | **1** (`0x0a`) |

A single end-of-line byte. PDF 32000-1 7.3.8.1 puts an EOL marker after the stream data and states it shall not be included in the stream length; these producers counted it. `DecompressionStream` rejects the stream outright, and the fully decoded payload is thrown away with it.

## The shape of the fix

The marker is accepted only after re-decoding the stream without it produces **exactly the same output length**. That preserves what the strict decoder was protecting: a truncated stream cannot be rescued this way, because removing a trailing byte never completes one. The re-decode only runs on the error path, so valid streams cost nothing.

Nothing else is trimmed, and this is deliberate. `testFlate` already asserts that a trailing NUL is rejected — that case still fails, untouched. So do spaces, tabs, and more than one marker. 7.3.8.1 specifies an EOL marker, not arbitrary padding, and the new cases pin that boundary in both directions:

- accepted: `LF`, `CR`, `CRLF`
- still rejected: `0x20`, `0x09`, `LF LF`, `LF CR`, `CRLF LF`, and the pre-existing NUL

## Checks

- `npm run test:file -- scripts/test-native-filter-semantics.mjs` — passes
- `npm test` — `tsc --noEmit` clean, 36 / 37 fast files pass
- `npm run test:integration` — 41 / 41
- `npm run test:unit` — 66 / 68
- both source PDFs now get past this filter (they hit unrelated later limits, reported separately)

The two failing files (`test-text-lod-core.mjs`, `test-room-segment-extractor.mjs`) also fail on `main` without this change; they are Windows-only path failures, unrelated.

## Scope

FlateDecode only. Independent of #4, #5 and #6.

Refs #2
