### PR TITLE
Fall back to the ICC alternate space when no resolver is configured

### DIFF
--- a/scripts/test-native-color-semantics.mjs
+++ b/scripts/test-native-color-semantics.mjs
@@ -146,7 +146,7 @@ function iccSpace({
   range,
   profile = iccProfile()
 } = {}) {
-  const entries = { N: count, Alternate: alternate };
+  const entries = alternate === null ? { N: count } : { N: count, Alternate: alternate };
   if (range !== undefined) entries.Range = range;
   return [name("ICCBased"), stream(entries, profile)];
 }
@@ -389,7 +389,11 @@ async function testIccProfilesAndKernelBoundary() {
   assert.equal(indirectDescription.kind, "ICCBased");
   assert.equal(indirectDescription.profile.length, 128, "bytes after the declared ICC size are discarded");
   assert.deepEqual(colors.defaultDecode(indirect), [0, 1, 0, 1, 0, 1]);
-  throwsCode(() => colors.convertToSrgb(indirect, [0, 0, 0]), "unsupported-color");
+  // No ICC resolver is configured here, so nothing has asked for profile
+  // fidelity and 8.6.5.5 hands the conversion to the alternate space. A
+  // resolver that is present and fails still raises; see the transform-result
+  // cases in test-pdf-session-icc-transform-resolver.mjs.
+  assert.deepEqual(colors.convertToSrgb(indirect, [0.25, 0.5, 0.75]), [0.25, 0.5, 0.75]);
 
   await rejectsCode(
     () => colors.add(iccSpace({ count: 2, profile: iccProfile() })),
@@ -429,6 +433,31 @@ async function testIccProfilesAndKernelBoundary() {
     })),
     "resource-limit"
   );
+
+  // ISO 32000-1 8.6.5.5: when the profile cannot be used, the alternate space
+  // stands in for it. One is always available -- /Alternate when supplied, and
+  // the Device space matching /N otherwise -- so having no ICC resolver must
+  // degrade the colour, not fail the document.
+  const withoutResolver = new NativePdfColorRegistry(document);
+  const explicitAlternate = await withoutResolver.add(iccSpace());
+  assert.deepEqual(
+    withoutResolver.convertToSrgb(explicitAlternate, [0.25, 0.5, 0.75]),
+    [0.25, 0.5, 0.75]
+  );
+
+  const impliedAlternate = await withoutResolver.add(iccSpace({ alternate: null }));
+  assert.deepEqual(
+    withoutResolver.convertToSrgb(impliedAlternate, [1, 0, 0]),
+    [1, 0, 0],
+    "/N 3 implies DeviceRGB when /Alternate is absent"
+  );
+
+  // /Range still maps the components onto [0, 1] before the alternate space
+  // sees them, exactly as it does for a resolver-backed profile above.
+  const rangedFallback = await withoutResolver.add(iccSpace({
+    range: [0.1, 0.9, 0.2, 0.8, 0.3, 0.7]
+  }));
+  closeRgb(withoutResolver.convertToSrgb(rangedFallback, [-1, 2, 0.5]), [0, 1, 0.5], 1e-12);
 
   let received = null;
   const kernelColors = new NativePdfColorRegistry(document, undefined, {

--- a/scripts/test-native-pdf-image-color.mjs
+++ b/scripts/test-native-pdf-image-color.mjs
@@ -342,10 +342,9 @@ async function testColors(functions) {
   deviceNColor.forEach((component) => closeTo(component, 0.25));
   const icc = await colors.add([{ kind: "name", value: "ICCBased" }, ref(11)]);
   assert.equal(colors.describe(icc).iccMetadata.dataColorSpace, "RGB ");
-  assert.throws(
-    () => colors.convertToSrgb(icc, [0, 0, 0]),
-    (error) => error instanceof PdfError && error.code === "unsupported-color"
-  );
+  // With no ICC resolver configured, 8.6.5.5 hands the conversion to the
+  // alternate space rather than failing the page.
+  assert.deepEqual(colors.convertToSrgb(icc, [0.25, 0.5, 0.75]), [0.25, 0.5, 0.75]);
   const kernelColors = new NativePdfColorRegistry(document, undefined, {
     iccKernel: {
       convertToSrgb(_profile, components) {

--- a/scripts/test-pdf-session-color.mjs
+++ b/scripts/test-pdf-session-color.mjs
@@ -159,7 +159,10 @@ try {
       { number: 5, body: tinyPdfStream("/N 3 /Alternate /DeviceRGB", profile) }
     ]
   });
-  await assertCompileCode(openPdf, iccBytes, "unsupported-color");
+  // An ICCBased space with no configured resolver compiles through its
+  // /Alternate. A resolver that is present and returns an invalid transform
+  // still fails; see test-pdf-session-icc-transform-resolver.mjs.
+  await assertCompiles(openPdf, iccBytes);
 
   const patternBytes = simplePagePdf(
     "/Resources << /ColorSpace << /P [/Pattern /DeviceRGB] >> >>",
@@ -206,6 +209,15 @@ function simplePagePdf(resourceEntries, content, extraObjects = []) {
       ...extraObjects
     ]
   });
+}
+
+async function assertCompiles(openPdf, bytes) {
+  const session = await openPdf({ kind: "bytes", bytes });
+  try {
+    await session.compilePage(0);
+  } finally {
+    await session.close();
+  }
 }
 
 async function assertCompileCode(openPdf, bytes, code) {

--- a/src/pdf/nativeColor.ts
+++ b/src/pdf/nativeColor.ts
@@ -1062,11 +1062,20 @@ export class NativePdfColorRegistry {
           break;
         }
         if (!this.iccKernel || !record.iccMetadata) {
-          throw new PdfError(
-            "unsupported-color",
-            "ICCBased color conversion requires a caller-owned ICC transform resolver.",
-            { details: { componentCount: record.componentCount } }
+          // ISO 32000-1 8.6.5.5: the alternate space stands in when the profile
+          // itself cannot be used. One is always present -- /Alternate when the
+          // space supplies it, and the Device space matching /N otherwise -- and
+          // its component count was checked when the space was parsed. Failing
+          // the whole render instead would discard a page over colour fidelity
+          // that the format itself declares optional.
+          rgb = this.convertInternal(
+            record.alternateSpaceIndex,
+            normalized,
+            next,
+            depth + 1,
+            signal
           );
+          break;
         }
         try {
           rgb = validateKernelRgb(this.iccKernel.convertToSrgb(


### PR DESCRIPTION
## The question first

This one changes behaviour you deliberately test for, so it is a proposal rather than a plain bug fix, and I have made the smaller of the two possible changes.

Three tests currently assert that an ICCBased space without a resolver raises `unsupported-color`: `test-native-color-semantics.mjs`, `test-native-pdf-image-color.mjs`, and `test-pdf-session-color.mjs`. I changed all three. That is not something I would do quietly, so here is the reasoning.

## What led me here

Real drawings fail to convert with:

```
ICCBased color conversion requires a caller-owned ICC transform resolver.
```

The contract that message points at cannot be satisfied from the public API. `BuildHepFromPdfOptions` has no field for an ICC resolver or kernel, and nothing in `src/` supplies one. So for anyone converting through `buildHep` or `PDFtoHEP.js`, every PDF carrying an ICCBased space fails, with no way to opt in to the thing the error asks for.

Meanwhile ISO 32000-1 8.6.5.5 already specifies the way out: the alternate space stands in when the profile itself cannot be used. It is always available — `/Alternate` when the space supplies one, and the Device space matching `/N` otherwise — and `parseIccBased` already resolves it, validates its component count, and stores it as `alternateSpaceIndex`. `Indexed`, `Separation` and `DeviceN` all already convert through exactly that index.

## What this changes

Only the case where **nothing has asked for profile fidelity**: no `iccTransformResolver`, no `iccKernel`. Conversion then goes through the alternate space, as 8.6.5.5 says it should.

A resolver that *is* present and fails still raises, unchanged — the `invalid-icc-transform-result` cases in `test-pdf-session-icc-transform-resolver.mjs` pass untouched, and so does the kernel-error path in `testIccProfilesAndKernelBoundary`.

`/Range` still maps components onto [0, 1] before the alternate space sees them, so a resolver-backed profile and this fallback receive identical inputs. That is asserted.

## The alternative

If you would rather keep the strict contract, the other fix is to expose `iccTransformResolver` (and `iccKernel`) through `BuildHepFromPdfOptions` so callers can actually satisfy it. I am happy to write that instead, or to put this fallback behind an option that defaults to today's behaviour. Tell me which you prefer and I will redo it.

## Checks

- `test-native-color-semantics.mjs`, `test-native-pdf-image-color.mjs`, `test-pdf-session-color.mjs`, `test-pdf-session-icc-transform-resolver.mjs` — all pass
- `npm test` — `tsc --noEmit` clean, 36 / 37 fast files pass
- `npm run test:integration` — 41 / 41
- `npm run test:unit` — 66 / 68
- two real PDFs get past this error (both then hit unrelated limits in the legacy vector path, which I have not touched)

The two failing files (`test-text-lod-core.mjs`, `test-room-segment-extractor.mjs`) also fail on `main`; they are Windows-only path failures.

Refs #2
