### PR TITLE
Treat repeated stitching Bounds as the empty subdomain they describe

### DIFF
--- a/scripts/test-hepr-function-evaluator.mjs
+++ b/scripts/test-hepr-function-evaluator.mjs
@@ -208,6 +208,15 @@ try {
     bounds: [0.5],
     encode: [0, 1, 0, 1]
   }));
+  // Repeated Bounds describe an empty subdomain, which selection can never
+  // reach. The unreachable segment here is `high`, whose outputs start at 10.
+  const plateau = await registry.add(stitching({
+    range: [0, 20],
+    functions: [low, high, low],
+    bounds: [0.5, 0.5],
+    encode: [0, 1, 0, 1, 0, 1]
+  }));
+
   const conditional = await registry.add(calculator(
     "{ dup .5 lt { 2 mul } { 1 exch sub 4 mul } ifelse }"
   ));
@@ -252,6 +261,7 @@ try {
     [cubic, [[0], [0.25], [0.5], [0.75], [1]]],
     [clampedExponential, [[-100], [0], [0.5], [1], [100]]],
     [joined, [[0], [0.25], [0.5], [0.75], [1]]],
+    [plateau, [[0], [0.25], [0.5], [0.75], [1]]],
     [conditional, [[0], [0.25], [0.5], [0.75], [1]]],
     [nestedConditional, [[0], [0.5], [1]]],
     [arithmetic, [[0]]],

--- a/scripts/test-native-function-semantics.mjs
+++ b/scripts/test-native-function-semantics.mjs
@@ -283,6 +283,22 @@ async function testExponentialAndStitchingFunctions() {
   closeTo(registry.evaluate(joined, [0.5])[0], 10);
   closeTo(registry.evaluate(joined, [1])[0], 20);
 
+  // ISO 32000-1 7.10.4 orders Bounds by increasing value, and producers do
+  // repeat one. That is an empty subdomain, not a disordered array: selection
+  // takes the first bound strictly above the input, so the segment between two
+  // equal bounds can never be chosen and its subfunction is never evaluated.
+  // Here that unreachable segment is `high`, whose outputs start at 10, so
+  // picking it up would be unmistakable.
+  const plateau = await registry.add(stitching({
+    range: [0, 20],
+    functions: [low, high, low],
+    bounds: [0.5, 0.5],
+    encode: [0, 1, 0, 1, 0, 1]
+  }));
+  closeTo(registry.evaluate(plateau, [0.25])[0], 0.5);
+  closeTo(registry.evaluate(plateau, [0.5])[0], 0);
+  closeTo(registry.evaluate(plateau, [1])[0], 1);
+
   const oneDegenerate = await registry.add(stitching({
     domain: [1, 1],
     range: [0, 1],

--- a/src/heprFunctionEvaluator.ts
+++ b/src/heprFunctionEvaluator.ts
@@ -534,7 +534,10 @@ function decodeRecord(
     for (let boundIndex = 0; boundIndex < bounds.length; boundIndex += 1) {
       const bound = bounds[boundIndex];
       const last = boundIndex === bounds.length - 1;
-      if (!(bound > previous && (bound < domain[1] || (last && bound === domain[1])))) {
+      // Repeated bounds describe an empty subdomain, not disorder: selection
+      // above takes the first bound strictly greater than the input, so that
+      // segment is unreachable. Only a decreasing bound is disorder.
+      if (!(bound >= previous && (bound < domain[1] || (last && bound === domain[1])))) {
         invalidFunction(path, "stitching bounds are unordered");
       }
       previous = bound;

--- a/src/pdf/nativeFunctions.ts
+++ b/src/pdf/nativeFunctions.ts
@@ -609,7 +609,11 @@ export class NativePdfFunctionRegistry {
       const isLast = index === bounds.length - 1;
       // The one explicit ISO exception permits only the last bound to equal
       // Domain[1]. That creates a final point subdomain evaluated at Encode[2i].
-      if (!(bound > previous && (bound < domain[1] || (isLast && bound === domain[1])))) {
+      // Repeated bounds are accepted as the empty subdomain they describe, not
+      // rejected as disorder: evaluateStitching selects the first bound strictly
+      // above the input, so a segment between two equal bounds is unreachable and
+      // its subfunction is never evaluated. Only a decreasing bound is disorder.
+      if (!(bound >= previous && (bound < domain[1] || (isLast && bound === domain[1])))) {
         throw new PdfError("invalid-object", "A stitching PDF function has unordered Bounds.");
       }
       previous = bound;


### PR DESCRIPTION
## What this fixes

A real PDF fails to render with `A stitching PDF function has unordered Bounds.` Probed at the failure point:

```
domain = [0, 1]
bounds = [0.14286, 0.14286]
```

The bounds are not out of order. They are equal, which describes an **empty subdomain** — and an empty subdomain can never be selected.

`evaluateStitching` picks the segment with `bounds.findIndex(bound => input < bound)`. For equal bounds `B`:

- `input < B` → segment before the plateau
- `input >= B` → `findIndex` returns -1 → the last segment

The segment between the two equal bounds is unreachable by construction, and its subfunction is never evaluated. Rejecting the function discards the whole page over a subfunction that would never run. There is also no division-by-zero risk in the degenerate interval, precisely because it is never selected.

So the check now rejects only a **decreasing** bound, which is genuine disorder. Everything else is untouched: the last bound may still equal `Domain[1]` under the existing ISO exception, and the multi-segment empty-domain guard above still fires first — the `domain: [1, 1]` case in `testStitchingFunctions` still rejects, through that guard.

## Both evaluators

The same validation and the same selection logic exist twice: `nativeFunctions.ts` for the parser and `heprFunctionEvaluator.ts` for the renderer-owned store. The first fix only moved the error message from one to the other, so both are updated together.

The new case in `test-hepr-function-evaluator.mjs` goes through the existing parity table, so the two evaluators are asserted to agree on it. In both new cases the unreachable segment is `high`, whose outputs start at 10 — selecting it by mistake would be unmistakable rather than subtle.

## Checks

- `test-native-function-semantics.mjs`, `test-hepr-function-evaluator.mjs` — pass
- `npm test` — `tsc --noEmit` clean, 36 / 37 fast files pass
- `npm run test:integration` — 41 / 41
- `npm run test:unit` — 66 / 68
- the source PDF gets past this error (it then hits a gradient subdivision limit, unrelated)

The two failing files (`test-text-lod-core.mjs`, `test-room-segment-extractor.mjs`) also fail on `main`; Windows-only path failures.

## Scope

Stitching bounds only. Independent of #4 through #8.

Refs #2
