### PR TITLE
Stop rejecting BaseFontBlend as a Multiple Master CFF font

### DIFF
--- a/scripts/test-native-cff-semantics.mjs
+++ b/scripts/test-native-cff-semantics.mjs
@@ -64,6 +64,23 @@ function testCffStructureAndType2Outlines() {
   assert.deepEqual(flex.bounds, [0, 0, 90, 50]);
 }
 
+function testBaseFontBlendIsNotMultipleMaster() {
+  // Top DICT 12 23 is BaseFontBlend, a delta left behind by Multiple Master
+  // tooling. It carries no interpolation state and no blend axes: the glyphs
+  // stay exactly the ones in CharStrings. Rejecting it as a Multiple Master
+  // font discards documents whose outlines are perfectly ordinary.
+  const baseline = NativeCffFont.parse(buildCffFixture());
+  const blended = NativeCffFont.parse(buildCffFixture({
+    topDictExtra: concat(dictInteger(408), dictInteger(-397), Uint8Array.of(12, 23))
+  }));
+  assert.equal(blended.numGlyphs, baseline.numGlyphs);
+  assert.deepEqual(blended.glyphNames, baseline.glyphNames);
+  assert.deepEqual(
+    blended.getGlyphOutline(1).commands,
+    baseline.getGlyphOutline(1).commands
+  );
+}
+
 function testFontMatrixNormalization() {
   const font = NativeCffFont.parse(buildCffFixture({
     fontMatrix: [0.002, 0, 0, 0.003, 0.01, -0.02]
@@ -224,7 +241,8 @@ function buildCffFixture(options = {}) {
   assert.equal(privateDictionary.length, 18);
   const localSubrsIndex = cffIndex(localSubrs);
   const fontMatrix = options.fontMatrix ?? null;
-  const placeholderTop = topDictionary(0, 0, 0, privateDictionary.length, 0, fontMatrix);
+  const topDictExtra = options.topDictExtra ?? new Uint8Array();
+  const placeholderTop = topDictionary(0, 0, 0, privateDictionary.length, 0, fontMatrix, topDictExtra);
   const placeholderTopIndex = cffIndex([placeholderTop]);
   const prefixLength = header.length + nameIndex.length + placeholderTopIndex.length +
     stringIndex.length + globalSubrsIndex.length;
@@ -238,7 +256,8 @@ function buildCffFixture(options = {}) {
     charStringsOffset,
     privateDictionary.length,
     privateOffset,
-    fontMatrix
+    fontMatrix,
+    topDictExtra
   );
   assert.equal(top.length, placeholderTop.length);
 
@@ -257,12 +276,13 @@ function buildCffFixture(options = {}) {
   );
 }
 
-function topDictionary(charset, encoding, charStrings, privateSize, privateOffset, fontMatrix) {
+function topDictionary(charset, encoding, charStrings, privateSize, privateOffset, fontMatrix, extra = new Uint8Array()) {
   const matrix = fontMatrix === null
     ? new Uint8Array()
     : concat(...fontMatrix.map((value) => dictReal(value)), Uint8Array.of(12, 7));
   return concat(
     matrix,
+    extra,
     dictInteger(charset), Uint8Array.of(15),
     dictInteger(encoding), Uint8Array.of(16),
     dictInteger(charStrings), Uint8Array.of(17),
@@ -381,6 +401,7 @@ function expectPdf(callback, code, message) {
 
 testCffStructureAndType2Outlines();
 testFontMatrixNormalization();
+testBaseFontBlendIsNotMultipleMaster();
 await testPdfFontSelectionIsSeparateFromToUnicode();
 testMalformedProgramsAndLimits();
 testDeprecatedPdfDotsectionCompatibility();

--- a/src/pdf/nativeCff.ts
+++ b/src/pdf/nativeCff.ts
@@ -170,9 +170,13 @@ export class NativeCffFont {
         "cff-cid-not-supported"
       );
     }
-    if (top.has(dictOperator(12, 20)) || top.has(dictOperator(12, 23))) {
+    // 12 20 is SyntheticBase: those glyphs are defined against another font and
+    // cannot be read from this CharStrings INDEX alone. 12 23 is BaseFontBlend,
+    // a delta left behind by Multiple Master tooling that carries no blend axes
+    // and no interpolation state, so a font holding it is read normally.
+    if (top.has(dictOperator(12, 20))) {
       throw cffUnsupported(
-        "Synthetic or Multiple Master CFF fonts are not supported.",
+        "Synthetic CFF fonts are not supported.",
         "cff-synthetic-not-supported"
       );
     }


### PR DESCRIPTION
## What this fixes

A real PDF fails with `Synthetic or Multiple Master CFF fonts are not supported.` Probed at the failure point, the font's Top DICT holds operator **12 23** with the values `[408, -397]`.

12 23 is not a Multiple Master marker. Per the CFF Top DICT layout it is **BaseFontBlend**, a `delta` array — which is exactly the shape of those two values. It is a leftover from Multiple Master tooling and carries no blend axes and no interpolation state. A font holding it has exactly the glyphs in its CharStrings INDEX.

So the check rejected an ordinary font over an inert metadata entry, and took the whole document with it.

## What still rejects

12 20 **SyntheticBase** — and that one is substantive: those glyphs are defined against another font and cannot be read from this CharStrings INDEX alone. Only the message changed there, since it no longer needs to mention Multiple Master.

## Test

`testBaseFontBlendIsNotMultipleMaster` parses the same fixture twice, with and without BaseFontBlend in its Top DICT, and asserts identical glyph names and identical outline commands. That proves the entry is inert rather than merely tolerated. `buildCffFixture` gained a `topDictExtra` option to make that possible.

## Checks

- `npm run test:file -- scripts/test-native-cff-semantics.mjs` — passes
- `npm test` — `tsc --noEmit` clean, 36 / 37 fast files pass
- `npm run test:integration` — 41 / 41
- `npm run test:unit` — 66 / 68
- the source PDF gets past this font (it then hits an ExtGState `/UCR2` refusal, reported separately)

The two failing files also fail on `main`; Windows-only path failures.

## Scope

CFF Top DICT only. Independent of #4 through #9.

Refs #2
